### PR TITLE
Fix for <label>s targeting themselves

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,10 +32,11 @@
                 </svg>
               </picture>
               <div class="sm-stack">
-                <label for="media-volume" id="media-volume">
+                <label for="media-volume">
                   Media volume
                 </label>
                 <input 
+                  id="media-volume" 
                   name="media-volume" 
                   aria-labelledby="media-volume" 
                   type="range" 
@@ -53,8 +54,9 @@
                 </svg>
               </picture>
               <div class="sm-stack">
-                <label for="call-volume" id="call-volume">Call volume</label>
+                <label for="call-volume">Call volume</label>
                 <input 
+                  id="call-volume" 
                   name="call-volume" 
                   aria-labelledby="call-volume" 
                   type="range" 
@@ -72,8 +74,9 @@
                 </svg>
               </picture>
               <div class="sm-stack">
-                <label for="ring-volume" id="ring-volume">Ring volume</label>
+                <label for="ring-volume">Ring volume</label>
                 <input 
+                  id="ring-volume" 
                   name="ring-volume" 
                   aria-labelledby="ring-volume" 
                   type="range" 
@@ -91,8 +94,9 @@
                 </svg>
               </picture>
               <div class="sm-stack">
-                <label for="alarm-volume" id="alarm-volume">Alarm volume</label>
+                <label for="alarm-volume">Alarm volume</label>
                 <input 
+                  id="alarm-volume" 
                   name="alarm-volume" 
                   aria-labelledby="alarm-volume" 
                   type="range" 


### PR DESCRIPTION
This fix moves `id` attributes off `<label>`s and onto the intended `<input>`s.

There remains several other issues identified by the [W3C validator](https://validator.w3.org), such as `Element svg not allowed as child of element picture in this context` and `Element h3 not allowed as child of element label in this context`.